### PR TITLE
Remove the silliness with wp_rtg_base_url

### DIFF
--- a/wp-remember-the-galleries/wp-remember-the-galleries.php
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.php
@@ -199,34 +199,6 @@ class WP_Remember_The_Galleries {
 	}
 
 	/**
-	 * Gets the base URL to the library with an optional file path appended to it.
-	 *
-	 * Assumes this is a standard installed plugin to determine the proper base URL path for assets.
-	 * If it is not, the wp_form_base_url filter should be used to alter the path.
-	 *
-	 * More info:
-	 *
-	 * There are times when hosting company's use symlinks to point to theme
-	 * and plugin directories and, unfortunately, these symlinks break wp core
-	 * functions. If you are having issues with wp-forms-api CSS and JS files
-	 * not loading, you can set the base URL to your plugin or theme using
-	 * this method.
-	 *
-	 * @access public
-	 *
-	 * @param string $file Optional.
-	 *
-	 * @return string
-	 */
-	static function url( $file = '' ) {
-		$filepath = ltrim( $file, '/' );
-
-		$url = trailingslashit( apply_filters( 'wp_rtg_base_url', plugins_url( '/', __FILE__ ) ) );
-
-		return $url . $filepath;
-	}
-
-	/**
 	 * Register and enqueue gallery management scripts.
 	 *
 	 * @action init
@@ -234,7 +206,7 @@ class WP_Remember_The_Galleries {
 	static function enqueue_scripts() {
 		global $current_screen;
 
-		wp_register_script( 'wp-rtg', self::url( 'wp-remember-the-galleries.js' ), array( 'jquery-ui-autocomplete' ), 1, true );
+		wp_register_script( 'wp-rtg', plugins_url( 'wp-remember-the-galleries.js', __FILE__ ), array( 'jquery-ui-autocomplete' ), 1, true );
 
 		$js_object = array(
 			'select-gallery' => __( "Select gallery or name a new gallery..." ),
@@ -274,7 +246,7 @@ class WP_Remember_The_Galleries {
 
 			wp_enqueue_media();
 			wp_enqueue_script( 'wp-rtg' );
-			wp_enqueue_style( 'wp-rtg', self::url( '/rtg-admin.css' ), array(), 1 );
+			wp_enqueue_style( 'wp-rtg', plugins_url( 'rtg-admin.css', __FILE__ ), array(), 1 );
 		}
 
 		wp_localize_script( 'wp-rtg', 'wpRememberTheGalleries',  $js_object );


### PR DESCRIPTION
This introduces another filter and a whole lot of extra code, when the perfectly usable `plugins_url` already exists. This can be filtered with a file in your mu-plugins to obtain the correct URL path when symlinks are being used.

You can use a mu-plugin similar to the following to achieve the same effect, replacing the "real" path parts of the URL with the correct URL relative to the theme root.

This all goes away when we inevitably transition the boston chefs project to Oomphrock.

``` php
<?php
define( 'EXTERNALS_REALPATH', '/Users/bendoh/vc/boston-chefs/externals' );

add_filter( 'plugins_url', function( $url, $path, $plugin ) {
    if ( preg_match( '#^' . EXTERNALS_REALPATH . '/[^/]+(/.+)$#', $plugin, $matches ) ) {
        $url = get_stylesheet_directory_uri() . '/externals' . dirname( $matches[1] ) . '/' . $path;
    }

    return $url;
}, 10, 3 );
```
