### PR TITLE
Fix buttons for posts; Only edit the toolbar for gallery-edit state

### DIFF
--- a/wp-remember-the-galleries/wp-remember-the-galleries.js
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.js
@@ -314,11 +314,12 @@
 			},
 
 			galleryEditToolbar: function(toolbar) {
-				if(wp.media.frame.id != 'library-gallery') {
+				if(wp.media.frame.state().id != 'gallery-edit') {
 					postEditToolbar.apply(this, arguments);
 				}
 				else {
 					this.toolbar.set(new media.view.Toolbar({ controller: this }));
+					this.updateButtonState();
 				}
 			},
 
@@ -336,7 +337,6 @@
 						controller: this,
 					});
 
-
 					toolbar.unset('insert');
 
 					toolbar.set({
@@ -346,12 +346,6 @@
 
 				this.saveGalleryButton && this.saveGalleryButton.model.set('disabled', !this.galleryDetails.get('name'));
 			},
-
-			activate: function() {
-				parent.prototype.activate && parent.prototype.activate.apply(this, arguments);
-
-				this.updateButtonState();
-			}
 		};
 	}
 


### PR DESCRIPTION
I BELIEVE the interface for getting the current frame state may have changed, which would have caused this to break. But I would need to dig further into it.

Don't update the toolbar state on activate: It might blow away the "Insert Image" toolbar.

I believe there's additional work to be done here to clean up this flow of buttons, but this at least fixes it enough to make it usable and not become a burning fire.
