### PR TITLE
Update gallery rows inline instead of refreshing page on bulk edit screen

### DIFF
--- a/wp-remember-the-galleries/wp-remember-the-galleries.js
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.js
@@ -287,13 +287,28 @@
 					}),
 					name: this.galleryDetails.get('name'),
 					term_id: this.galleryDetails.get('id'),
-					settings: selection.gallery.attributes
+					settings: selection.gallery.attributes,
+					context: this.galleryDetails.get('context'),
 				};
+
+				var $target = this.galleryDetails.get('target') && $(this.galleryDetails.get('target'));
 
 				var save = function() {
 					media.post('rtg_save_gallery', saveData).done(function(data) {
 						media.frame && media.frame.close();
-						location.reload();
+						switch (saveData.context) {
+							case 'bulk-edit':
+								if (data.columns) {
+									for(var column in data.columns) {
+										$target.parent().parent().find('.' + column).html(data.columns[column]);
+									}
+								}
+							break;
+
+							case 'new-gallery':
+								location.reload();
+							break;
+						}
 					}).fail(function(data) {
 						if(data.message === 'empty-name') {
 							this.router.get().$el.find('input').focus();
@@ -467,6 +482,8 @@
 
 		details.set('id', id);
 		details.set('name', name);
+		details.set('target', this);
+		details.set('context', 'bulk-edit');
 
 		wp.media.frame.open();
 		wp.media.frame.setIds(ids);
@@ -484,6 +501,7 @@
 
 		var details = wp.media.frame.galleryDetails;
 		details.clear();
+		details.set('context', 'new-gallery');
 
 		wp.media.frame.open();
 		wp.media.frame.setState('gallery-library');

--- a/wp-remember-the-galleries/wp-remember-the-galleries.js
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.js
@@ -481,7 +481,6 @@
 
 		details.set('id', id);
 		details.set('name', name);
-		details.set('target', this);
 		details.set('context', 'bulk-edit');
 
 		wp.media.frame.open();

--- a/wp-remember-the-galleries/wp-remember-the-galleries.js
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.js
@@ -291,16 +291,15 @@
 					context: this.galleryDetails.get('context'),
 				};
 
-				var $target = this.galleryDetails.get('target') && $(this.galleryDetails.get('target'));
-
 				var save = function() {
 					media.post('rtg_save_gallery', saveData).done(function(data) {
 						media.frame && media.frame.close();
 						switch (saveData.context) {
 							case 'bulk-edit':
 								if (data.columns) {
+									// replace matching columns with new markup
 									for(var column in data.columns) {
-										$target.parent().parent().find('.' + column).html(data.columns[column]);
+										$('.open-gallery-edit[data-id='+saveData.term_id+']').closest('.' + column).html(data.columns[column]);
 									}
 								}
 							break;

--- a/wp-remember-the-galleries/wp-remember-the-galleries.php
+++ b/wp-remember-the-galleries/wp-remember-the-galleries.php
@@ -147,7 +147,10 @@ class WP_Remember_The_Galleries {
 	/**
 	 * Render "Image" column
 	 */
-	static function render_custom_columns( $column, $post_id ) {
+	static function render_custom_columns( $column, $post_id, $echo = true ) {
+		if ( !$echo ) {
+			ob_start();
+		}
 		switch ( $column ) {
 		case 'gallerytitle' :
 		case 'images' :
@@ -188,7 +191,10 @@ class WP_Remember_The_Galleries {
 			}
 			break;
 		}
-	}
+		if ( !$echo ) {
+			return ob_get_clean();
+		}
+ 	}
 
 	/**
 	 * Render relevant media templates
@@ -284,7 +290,11 @@ class WP_Remember_The_Galleries {
 			'settings' => array(
 				'flags' => FILTER_REQUIRE_ARRAY
 			),
-			'yes' => FILTER_VALIDATE_BOOLEAN
+			'yes' => FILTER_VALIDATE_BOOLEAN,
+			'context' => array(
+				'filter' => FILTER_SANITIZE_STRING,
+				'flags' => FILTER_REQUIRE_SCALAR
+			),
 		) );
 
 		if ( !$input ) {
@@ -345,6 +355,7 @@ class WP_Remember_The_Galleries {
 			}
 		}
 
+		$new = false;
 		if( !$term_id ) {
 			$post_id = wp_insert_post( array(
 				'post_title' => $gallery_name,
@@ -363,6 +374,7 @@ class WP_Remember_The_Galleries {
 			}
 
 			$term_id = $term_info['term_id'];
+			$new = true;
 		}
 		else {
 			$post_id = self::get_post_id( $term_id );
@@ -405,7 +417,17 @@ class WP_Remember_The_Galleries {
 		}
 
 		_update_generic_term_count( $term_id, self::entity );
-		wp_send_json_success( 'gallery-saved' );
+		$response = array(
+			'response' => 'gallery-saved',
+			'isNew' => $new,
+		);
+		if ( isset( $context ) && $context === 'bulk-edit' ) {
+			$response['columns'] = array(
+				'images' => self::render_custom_columns( 'images', $post_id, false ),
+				'gallerytitle' => self::render_custom_columns( 'gallerytitle', $post_id, false ),
+			);
+		}
+		wp_send_json_success( $response );
 	}
 
 	/**


### PR DESCRIPTION
- The only action that prompts a page refresh now is creating a new gallery from the bulk edit screen
- This also prevents a refresh on post edit pages, which is problematic when post content has been edited and not yet saved (and a refresh is not necessary there)
